### PR TITLE
Add support for Gitlab CI

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -63,6 +63,7 @@ The following recipes are available:
 * `git-commit`          : Tries to determine the Git commit ID for the build
 * `git-status`          : Outputs the result of `git status`, and tags the build as `dirty` if there are uncommitted or changes files locally
 * `git-diff-to-gist`    : Pushes the result of `git diff` to a Gist and creates a link in the build scan to this diff
+* `gitlab-ci`           : Detects a build running under https://docs.gitlab.com/ce/ci/README.html[GitLab CI], tags it as `CI` and outputs information about GitLab CI environment
 * `teamcity`            : Detects a build running under https://www.jetbrains.com/teamcity/[TeamCity], tags it as `CI`, and adds a link to the build
 * `travis-ci`           : Detects a build running under https://travis-ci.org[Travis CI], tags it as `CI` and outputs information about the Travis environment
 * `disk-usage`          : Shows information about Gradle disk usage. It will scan your `$HOME/.gradle` directory as well as your project directory. Note that depending on your disk type, OS, disk usage and file system, this can turn to be very slow and add a non negligeable time at build start. You should therefore use this recipe with care. This recipe only works on Linux and Mac OS.

--- a/src/recipes/gitlab-ci.groovy
+++ b/src/recipes/gitlab-ci.groovy
@@ -4,7 +4,7 @@ if (!(env.CI && env.GITLAB_CI)) {
     return
 }
 
-buildScan {
+buildScan.with {
     tag 'CI'
     link 'GitLab CI Job', "${env.CI_PROJECT_URL}/-/jobs/${env.CI_JOB_ID}"
     link 'GitLab CI Pipeline', "${env.CI_PROJECT_URL}/pipelines/${env.CI_PIPELINE_ID}"

--- a/src/recipes/gitlab-ci.groovy
+++ b/src/recipes/gitlab-ci.groovy
@@ -6,6 +6,7 @@ if (!(env.CI && env.GITLAB_CI)) {
 
 buildScan.with {
     tag 'CI'
+    link 'GitLab Project', env.CI_PROJECT_URL
     link 'GitLab CI Job', "${env.CI_PROJECT_URL}/-/jobs/${env.CI_JOB_ID}"
     link 'GitLab CI Pipeline', "${env.CI_PROJECT_URL}/pipelines/${env.CI_PIPELINE_ID}"
 
@@ -22,8 +23,11 @@ buildScan.with {
     value 'GitLab CI Job Name', env.CI_JOB_NAME
     value 'GitLab CI Job Stage', env.CI_JOB_STAGE
     value 'GitLab CI Pipeline Source', env.CI_PIPELINE_SOURCE
-    value 'GitLab CI Environment', env.CI_ENVIRONMENT_NAME
-    value 'GitLab CI Environment URL', env.CI_ENVIRONMENT_URL
+    if (env.CI_ENVIRONMENT_URL) {
+        link "${env.CI_ENVIRONMENT_NAME} environment", env.CI_ENVIRONMENT_URL
+        value 'GitLab CI Environment', env.CI_ENVIRONMENT_NAME
+        value 'GitLab CI Environment URL', env.CI_ENVIRONMENT_URL
+    }
     value 'GitLab CI Runner ID', env.CI_RUNNER_ID
     value 'GitLab CI Runner Desc', env.CI_RUNNER_DESCRIPTION
     value 'GitLab CI Runner Tags', env.CI_RUNNER_TAGS

--- a/src/recipes/gitlab-ci.groovy
+++ b/src/recipes/gitlab-ci.groovy
@@ -14,9 +14,11 @@ buildScan.with {
     value 'GitLab CI Project Namespace', env.CI_PROJECT_NAMESPACE
     value 'GitLab CI Project Path', env.CI_PROJECT_PATH
     value 'GitLab CI Project URL', env.CI_PROJECT_URL
+    tag env.CI_COMMIT_REF_NAME
     value 'GitLab CI Built Branch', env.CI_COMMIT_REF_NAME
     value 'GitLab CI Built Commit', env.CI_COMMIT_SHA
     if (env.CI_COMMIT_TAG) {
+        tag env.CI_COMMIT_TAG
         value 'GitLab CI Tag', env.CI_COMMIT_TAG
     }
     value 'GitLab CI Job Started Manually', env.CI_JOB_MANUAL

--- a/src/recipes/gitlab-ci.groovy
+++ b/src/recipes/gitlab-ci.groovy
@@ -1,0 +1,37 @@
+def env = System.getenv()
+
+if (!(env.CI && env.GITLAB_CI)) {
+    return
+}
+
+buildScan {
+    tag 'CI'
+    link 'GitLab CI Job', "${env.CI_PROJECT_URL}/-/jobs/${env.CI_JOB_ID}"
+    link 'GitLab CI Pipeline', "${env.CI_PROJECT_URL}/pipelines/${env.CI_PIPELINE_ID}"
+
+    value 'GitLab CI Project Name', env.CI_PROJECT_NAME
+    value 'GitLab CI Project Namespace', env.CI_PROJECT_NAMESPACE
+    value 'GitLab CI Project Path', env.CI_PROJECT_PATH
+    value 'GitLab CI Project URL', env.CI_PROJECT_URL
+    value 'GitLab CI Built Branch', env.CI_COMMIT_REF_NAME
+    value 'GitLab CI Built Commit', env.CI_COMMIT_SHA
+    if (env.CI_COMMIT_TAG) {
+        value 'GitLab CI Tag', env.CI_COMMIT_TAG
+    }
+    value 'GitLab CI Job Started Manually', env.CI_JOB_MANUAL
+    value 'GitLab CI Job Name', env.CI_JOB_NAME
+    value 'GitLab CI Job Stage', env.CI_JOB_STAGE
+    value 'GitLab CI Pipeline Source', env.CI_PIPELINE_SOURCE
+    value 'GitLab CI Environment', env.CI_ENVIRONMENT_NAME
+    value 'GitLab CI Environment URL', env.CI_ENVIRONMENT_URL
+    value 'GitLab CI Runner ID', env.CI_RUNNER_ID
+    value 'GitLab CI Runner Desc', env.CI_RUNNER_DESCRIPTION
+    value 'GitLab CI Runner Tags', env.CI_RUNNER_TAGS
+    value 'GitLab CI Server Name', env.CI_SERVER_NAME
+    value 'GitLab CI Server Revision', env.CI_SERVER_REVISION
+    value 'GitLab CI Server Version', env.CI_SERVER_VERSION
+    value 'GitLab CI User ID', env.GITLAB_USER_ID
+    value 'GitLab CI User Email', env.GITLAB_USER_EMAIL
+    value 'GitLab CI User Login', env.GITLAB_USER_LOGIN
+    value 'GitLab CI User Name', env.GITLAB_USER_NAME
+}


### PR DESCRIPTION
If build is being executed on [GitLab CI](https://docs.gitlab.com/ce/ci/README.html) a number of values based on [variables](https://docs.gitlab.com/ce/ci/variables/README.html) GitLab CI exposes will be automatically added to the build scan.
