### PR TITLE
Java and Kotlin friendlier API

### DIFF
--- a/src/main/groovy/me/champeau/gradle/buildscans/RecipeExtension.groovy
+++ b/src/main/groovy/me/champeau/gradle/buildscans/RecipeExtension.groovy
@@ -31,6 +31,10 @@ class RecipeExtension {
         recipes.apply(recipeName, params)
     }
 
+    void recipe(String recipeName, Map<String, String> params) {
+        recipes.apply(recipeName, params)
+    }
+
     void recipes(String... recipeList) {
         recipeList.each { String recipe ->
             recipes.apply(recipe)


### PR DESCRIPTION
Groovy named parameters rely on first method argument being a Map like in:

```groovy
buildScanRecipes {
    recipe 'git-commit', baseUrl: 'https://github.com/melix/gradle-buildscan-recipes/tree'
}
```

which invokes `RecipeExtension#recipe(Map<String,String>, String)`.

Invoking the same from a plugin written in Java or Kotlin, or a Kotlin build script requires passing arguments before the recipe name.

This commits adds a second recipe(..) method to allow Java and Kotlin consumers to name the recipe first:

```kotlin
// build.gradle.kts
plugins {
    id("com.gradle.build-scan") version "1.10.1"
    id("me.champeau.buildscan-recipes") version "0.2.3"
}

buildScanRecipes {
    recipe("git-commit", mapOf("baseUrl" to "https://github.com/melix/gradle-buildscan-recipes/tree"))
}
```
